### PR TITLE
has-transformed-position

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author = "yaq developers"
 home-page = "https://yaq.fyi"
 description-file = "README.md"
 requires-python = ">=3.7"
-requires = ["yaqd-core>=2021.12.0", "adafruit-circuitpython-motorkit", "adafruit-circuitpython-motor", "gpiozero"]
+requires = ["yaqd-core>=2022.7.0", "adafruit-circuitpython-motorkit", "adafruit-circuitpython-motor", "gpiozero"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",

--- a/yaqd_adafruit/_adafruit_stepper_motor_hat.py
+++ b/yaqd_adafruit/_adafruit_stepper_motor_hat.py
@@ -2,10 +2,10 @@ import asyncio
 from typing import Dict, Any
 
 import gpiozero  # type: ignore
-from yaqd_core import UsesI2C, UsesSerial, HasLimits, HasPosition, IsHomeable, IsDaemon
+from yaqd_core import UsesI2C, UsesSerial, HasTransformedPosition, HasLimits, HasPosition, IsHomeable, IsDaemon
 
 
-class AdafruitStepperMotorHat(UsesI2C, UsesSerial, IsHomeable, HasLimits, HasPosition, IsDaemon):
+class AdafruitStepperMotorHat(UsesI2C, UsesSerial, HasTransformedPosition, IsHomeable, HasLimits, HasPosition, IsDaemon):
     _kind = "adafruit-stepper-motor-hat"
 
     def __init__(self, name, config, config_filepath):
@@ -24,6 +24,7 @@ class AdafruitStepperMotorHat(UsesI2C, UsesSerial, IsHomeable, HasLimits, HasPos
             self._upper_pin = gpiozero.InputDevice(
                 config["upper_limit_switch"]["pin"], pull_up=True
             )
+        self._native_units = self._units
 
     async def _do_step(self, backward=False):
         from adafruit_motor import stepper  # type: ignore

--- a/yaqd_adafruit/adafruit-stepper-motor-hat.avpr
+++ b/yaqd_adafruit/adafruit-stepper-motor-hat.avpr
@@ -172,6 +172,42 @@
                 "type": "array"
             }
         },
+        "get_native_destination": {
+            "doc": "Get the destination in native coordinates.",
+            "origin": "has-transformed-position",
+            "request": [],
+            "response": "double"
+        },
+        "get_native_limits": {
+            "doc": "Returns limits in the relative coordinate system.",
+            "origin": "has-transformed-position",
+            "request": [],
+            "response": {
+                "items": "double",
+                "type": "array"
+            }
+        },
+        "get_native_position": {
+            "doc": "Get the current position in native coordinates.",
+            "origin": "has-transformed-position",
+            "request": [],
+            "response": "double"
+        },
+        "get_native_reference": {
+            "doc": "Get the reference position in native coordinates.",
+            "origin": "has-transformed-position",
+            "request": [],
+            "response": "double"
+        },
+        "get_native_units": {
+            "doc": "Get the units of native coordinates.",
+            "origin": "has-transformed-position",
+            "request": [],
+            "response": [
+                "null",
+                "string"
+            ]
+        },
         "get_position": {
             "doc": "Get current daemon position.",
             "origin": "has-position",
@@ -222,6 +258,28 @@
             ],
             "response": "boolean"
         },
+        "set_native_position": {
+            "doc": "Set the current position in native coordinates.",
+            "origin": "has-transformed-position",
+            "request": [
+                {
+                    "name": "native_coordinate",
+                    "type": "double"
+                }
+            ],
+            "response": "null"
+        },
+        "set_native_reference": {
+            "doc": "Set the reference position in native coordinates.\nReference position need not be within hardware limits.",
+            "origin": "has-transformed-position",
+            "request": [
+                {
+                    "name": "native_coordinate",
+                    "type": "double"
+                }
+            ],
+            "response": "null"
+        },
         "set_position": {
             "doc": "Give the daemon a new destination, and begin motion towards that destination.",
             "origin": "has-position",
@@ -255,19 +313,74 @@
                 }
             ],
             "response": "null"
+        },
+        "to_native": {
+            "doc": "Convert a transformed coordinate to native.\nThis is for debugging purposes and is discouraged in normal use.",
+            "origin": "has-transformed-position",
+            "request": [
+                {
+                    "name": "transformed_coordinate",
+                    "type": "double"
+                }
+            ],
+            "response": "double"
+        },
+        "to_transformed": {
+            "doc": "Convert a native coordinate to transformed.\nThis is for debugging purposes and is discouraged in normal use.",
+            "origin": "has-transformed-position",
+            "request": [
+                {
+                    "name": "native_coordinate",
+                    "type": "double"
+                }
+            ],
+            "response": "double"
         }
     },
     "properties": {
         "destination": {
-            "control_kind": "normal",
+            "control_kind": "hinted",
             "dynamic": true,
             "getter": "get_destination",
-            "limits_getter": null,
+            "limits_getter": "get_limits",
             "options_getter": null,
             "record_kind": "data",
-            "setter": null,
+            "setter": "set_position",
             "type": "double",
             "units_getter": "get_units"
+        },
+        "native_destination": {
+            "control_kind": "normal",
+            "dynamic": true,
+            "getter": "get_native_destination",
+            "limits_getter": "get_native_limits",
+            "options_getter": null,
+            "record_kind": "metadata",
+            "setter": "set_native_position",
+            "type": "double",
+            "units_getter": "get_native_units"
+        },
+        "native_position": {
+            "control_kind": "normal",
+            "dynamic": true,
+            "getter": "get_native_position",
+            "limits_getter": null,
+            "options_getter": null,
+            "record_kind": "metadata",
+            "setter": null,
+            "type": "double",
+            "units_getter": "get_native_units"
+        },
+        "native_reference_position": {
+            "control_kind": "normal",
+            "dynamic": true,
+            "getter": "get_native_reference",
+            "limits_getter": null,
+            "options_getter": null,
+            "record_kind": "metadata",
+            "setter": "set_native_reference",
+            "type": "double",
+            "units_getter": "get_native_units"
         },
         "position": {
             "control_kind": "hinted",
@@ -276,7 +389,7 @@
             "limits_getter": "get_limits",
             "options_getter": null,
             "record_kind": "data",
-            "setter": "set_position",
+            "setter": null,
             "type": "double",
             "units_getter": "get_units"
         }
@@ -298,6 +411,12 @@
             "origin": "has-limits",
             "type": "array"
         },
+        "native_reference_position": {
+            "default": 0.0,
+            "doc": "The reference position, expressed in native coordinates.\nDefault is `0.0`",
+            "origin": "has-transformed-position",
+            "type": "double"
+        },
         "position": {
             "default": 0,
             "origin": "has-position",
@@ -307,6 +426,7 @@
     "traits": [
         "has-limits",
         "has-position",
+        "has-transformed-position",
         "is-daemon",
         "is-homeable",
         "uses-i2c",

--- a/yaqd_adafruit/adafruit-stepper-motor-hat.toml
+++ b/yaqd_adafruit/adafruit-stepper-motor-hat.toml
@@ -1,6 +1,6 @@
 protocol = "adafruit-stepper-motor-hat"
 doc = ""
-traits = ["uses-i2c", "uses-serial", "has-limits", "has-position", "is-homeable", "is-daemon"]
+traits = ["uses-i2c", "uses-serial", "has-transformed-position", "has-limits", "has-position", "is-homeable", "is-daemon"]
 hardware = ["adafruit:2348", "raspberry-pi:4b"]
 
 [links]


### PR DESCRIPTION
Implements has-transformed-position trait on stepper

Currently using default transform--can use `native_reference_position` to offset coordinates.